### PR TITLE
fix(configuration): Remove unnecessary options

### DIFF
--- a/src/JestTestRunner.ts
+++ b/src/JestTestRunner.ts
@@ -23,6 +23,7 @@ const DEFAULT_OPTIONS: Object = {
   setupFiles: [],
   snapshotSerializers: [],
   testEnvironment: 'jest-environment-jsdom',
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
   testRunner: 'jest-jasmine2',
   verbose: true
 };

--- a/src/JestTestRunner.ts
+++ b/src/JestTestRunner.ts
@@ -23,7 +23,6 @@ const DEFAULT_OPTIONS: Object = {
   setupFiles: [],
   snapshotSerializers: [],
   testEnvironment: 'jest-environment-jsdom',
-  testRegex: '.*Spec\\.js$',
   testRunner: 'jest-jasmine2',
   verbose: true
 };

--- a/src/JestTestRunner.ts
+++ b/src/JestTestRunner.ts
@@ -40,7 +40,8 @@ export default class JestTestRunner extends EventEmitter implements TestRunner {
     log.debug(`Received options ${JSON.stringify(options)}`);
 
     this.options = _.assign(DEFAULT_OPTIONS, {
-      rootDir: process.cwd()
+      rootDir: process.cwd(),
+      testPathDirs: [process.cwd()]
     });
     log.debug(`Using options ${JSON.stringify(this.options)}`);
     

--- a/src/JestTestRunner.ts
+++ b/src/JestTestRunner.ts
@@ -40,9 +40,7 @@ export default class JestTestRunner extends EventEmitter implements TestRunner {
     log.debug(`Received options ${JSON.stringify(options)}`);
 
     this.options = _.assign(DEFAULT_OPTIONS, {
-      rootDir: process.cwd(),
-      roots: process.cwd(),
-      testPathDirs: [process.cwd()]
+      rootDir: process.cwd()
     });
     log.debug(`Using options ${JSON.stringify(this.options)}`);
     

--- a/testResources/sampleProject/src/__tests__/AddFailedSpec.js
+++ b/testResources/sampleProject/src/__tests__/AddFailedSpec.js
@@ -19,4 +19,4 @@ describe('Add', function() {
 
     expect(actual).toBe(expected);
   });
-})
+});


### PR DESCRIPTION
These changes result in behaviour closer to the Jest default, and will work in a wider range of scenarios, until some work can be completed on reading the jest configuration from package.json or stryker.conf.js