### PR TITLE
Add support for Jest v20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@ language: node_js
 node_js:
   - "7"
   - "6"
+env:
+  - JEST_VERSION=18.0.0
+  - JEST_VERSION=19.0.0
+  - JEST_VERSION=20.0.0
 install: npm install
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  # Install desired version of Jest
+  - npm i -D jest@${JEST_VERSION} jest-cli@${JEST_VERSION}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Stryker Jest Runner
 A plugin to use the [Jest](http://facebook.github.io/jest/) test runner in [Stryker](http://stryker-mutator.github.io), the JavaScript mutation testing framework.
 
-## Install
+## Installation
 
 Install stryker-jest-runner locally within your project folder, like so:
 
@@ -14,7 +14,7 @@ Install stryker-jest-runner locally within your project folder, like so:
 npm i --save-dev stryker-jest-runner
 ```
 
-## Peer dependencies
+### Peer dependencies
 
 The `stryker-jest-runner` is a plugin for Stryker to enable Jest as a test runner. 
 As such, you should make sure you have the correct versions of its dependencies installed:
@@ -22,19 +22,26 @@ As such, you should make sure you have the correct versions of its dependencies 
 * `jest-cli`
 * `jest-runtime`
 
-For the current versions, see the `peerDependencies` section in the [package.json](https://github.com/stryker-mutator/stryker-jest-runner/blob/master/package.json).
+For the minimum supported versions, see the `peerDependencies` section in [package.json](https://github.com/stryker-mutator/stryker-jest-runner/blob/master/package.json).
+For all supported version, see the `env` section in [.travis.yml](https://github.com/stryker-mutator/stryker-jest-runner/blob/master/.travis.yml).
 
 ## Configuring
 
 For the time being, the Jest runner uses a default configuration.
 But pull requests are - obviously - welcome. 
 
-### Load the plugin
+### Loading the plugin
 
 In order to use the `stryker-jest-runner` it must be loaded in the Stryker mutation testing framework via the Stryker configuration. 
 The easiest way to achieve this, is *not have a `plugins` section* in your config file. That way, all `node_modules` starting with `stryker-` will be loaded.
 
-### Use the test runner
+### Using the test runner
 
 In order to use Jest as the test runner, you simply specify it in your config file: `testRunner: 'jest'`.
 Note that coverageAnalysis is not yet supported, so you must explicitly set it to `off` in your Stryker configration.
+Again, pull requests are - obviously - welcome.
+
+## Contributing
+
+Before you start hacking along, make sure to install a supported version of Jest inside your working copy.
+The versions supported are listed above.

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "homepage": "https://github.com/stryker-mutator/stryker-jest-runner",
   "peerDependencies": {
-    "jest-cli": "^18.1.0",
-    "jest-runtime": "^18.1.0",
+    "jest-cli": ">=18.0.0",
+    "jest-runtime": ">=18.0.0",
     "stryker-api": "^0.5.0"
   },
   "devDependencies": {
@@ -54,9 +54,6 @@
     "grunt-ts": "^6.0.0-beta.3",
     "grunt-tslint": "^4.0.0",
     "istanbul": "^0.4.4",
-    "jest": "^18.1.0",
-    "jest-cli": "^18.0.0",
-    "jest-runtime": "^18.1.0",
     "load-grunt-tasks": "^3.5.2",
     "mocha": "^3.0.2",
     "sinon": "^1.17.5",

--- a/src/JestVersionAdapters.ts
+++ b/src/JestVersionAdapters.ts
@@ -1,0 +1,56 @@
+const runTest = require('jest-cli/build/runTest');
+const Runtime = require('jest-runtime');
+
+const Console = require('console').Console;
+
+import * as log4js from 'log4js';
+const log = log4js.getLogger('JestAdapter');
+
+const console = new Console(process.stdout, process.stderr);
+
+/**
+ * Interface to decouple the runner from various versions of Jest.
+ * Since the runner hooks into some implementation modules of Jest,
+ * we cannot expect the API's to be stable at this time.
+ */
+abstract class JestAdapter {
+  abstract buildHasteContext(options: any): Promise<any>;
+  abstract runTest(path: string, options: any, resolver: any): Promise<any>;
+}
+
+class JestPre20Adapter extends JestAdapter {
+  public buildHasteContext(options: any): Promise<any> {
+    const { maxWorkers } = options;
+    return Runtime.createHasteContext(options, { console, maxWorkers });
+  }
+
+  public runTest(path: string, options: any, resolver: any): Promise<any> {
+    return runTest(path, options, resolver);
+  }
+}
+
+class JestPost20Adapter extends JestAdapter {
+  public buildHasteContext(options: any): Promise<any> {
+    const { maxWorkers } = options;
+    return Runtime.createContext(options, { console,  maxWorkers });
+  }
+  
+  public runTest(path: string, options: any, resolver: any): Promise<any> {
+    const globalConfig = {};
+    return runTest(path, globalConfig, options, resolver);
+  }
+}
+
+const findJestAdapter = () => {
+  const pre20 = typeof Runtime.createHasteContext !== 'undefined';
+  log.info(`Detected Jest ${pre20 ? 'pre' : 'post'} v20.0.0`);
+  const adapter = pre20 ? new JestPre20Adapter() : new JestPost20Adapter();
+  return (adapter as JestAdapter);
+};
+
+export {
+  JestAdapter,
+  JestPre20Adapter,
+  JestPost20Adapter,
+  findJestAdapter,
+}


### PR DESCRIPTION
As reported in #15, Jest 20 came out and the Jest runner for Stryker doesn't work properly with it.
This PR fixes that by introducing version-specific adapters for each Jest version.
For this time, there are just two flavors: pre- and post v20.
As Jest and Stryker continue to develop, we could easily add more adapters.

Also, I've enhanced the Travis set-up so we can easily test with multiple version of Jest at the same time.