### PR TITLE
chore(dependencies): Update to stryker-api 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "jest-cli": ">=18.0.0",
     "jest-runtime": ">=18.0.0",
-    "stryker-api": "^0.9.0"
+    "stryker-api": "^0.10.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.32",


### PR DESCRIPTION
stryker-api 0.10.0 contains a [breaking change for test frameworks](https://github.com/stryker-mutator/stryker/blob/master/packages/stryker-api/CHANGELOG.md) but since this package doesn't have one, you should have no problem bumping your version.