### PR TITLE
feat(runner) Add support for Jest v21 (#21)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - JEST_VERSION=18.0.0
   - JEST_VERSION=19.0.0
   - JEST_VERSION=20.0.0
+  - JEST_VERSION=21.0.0
 install: npm install
 before_script:
   - export DISPLAY=:99.0

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/log4js": "0.0.32",
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.45",
+    "@types/semver": "^5.4.0",
     "@types/sinon": "^1.16.29",
     "@types/sinon-chai": "^2.7.26",
     "chai": "^3.5.0",
@@ -64,7 +65,8 @@
   },
   "dependencies": {
     "lodash": "^4.13.1",
-    "log4js": "^1.0.1"
+    "log4js": "^1.0.1",
+    "semver": "5.4.1"
   },
   "contributors": [
     "Maarten Mulders <mthmulders@users.noreply.github.com>",


### PR DESCRIPTION
This PR adds support for Jest 21 in three steps:

1. it changes the way we detect the version of Jest installed. Instead of looking at whether or not some API is present, we now look at `jest-cli/package.json`.
2. it only imports the relevant Jest API's when the version of Jest has been determined (lazy loading).
3. it adds support for Jest 21. In Jest 21, some files have been renamed, which is why eager loading didn't suffice any more.