### PR TITLE
Feat(ConfigEditor): Add functionality to use jest.config.js

### DIFF
--- a/test/integration/JestConfigEditorSpec.ts
+++ b/test/integration/JestConfigEditorSpec.ts
@@ -69,6 +69,22 @@ describe('Integration JestConfigEditor', () => {
     expect(config.jest.config).to.deep.equal(expectedResult);
   });
 
+  it('should load the jest configuration from the jest.config.js', () => {
+    getProjectRootStub.returns(path.join(process.cwd(), 'testResources', 'exampleProjectWithExplicitJestConfig'));
+
+    jestConfigEditor.edit(config);
+
+    expect(config.jest.project).to.equal('default');
+    expect(config.jest.config).to.deep.equal({
+      collectCoverage: false,
+      moduleFileExtensions: ['js', 'json', 'jsx', 'node'],
+      testEnvironment: 'jest-environment-jsdom',
+      testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
+      testRunner: 'jest-jasmine2',
+      verbose: true
+    });
+  });
+
   it('should load the jest configuration from the package.json', () => {
     getProjectRootStub.returns(path.join(process.cwd(), 'testResources', 'exampleProject'));
 

--- a/test/integration/StrykerJestRunnerSpec.ts
+++ b/test/integration/StrykerJestRunnerSpec.ts
@@ -18,8 +18,7 @@ describe('Integration StrykerJestRunner', function () {
 
   let jestConfigEditor: JestConfigEditor;
   let runOptions: RunnerOptions;
-  let getProjectRootStub: sinon.SinonStub;
-
+  let processCwdStub: sinon.SinonStub;
   let sandbox: sinon.SinonSandbox;
 
   // Names of the tests in the example projects
@@ -35,7 +34,7 @@ describe('Integration StrykerJestRunner', function () {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
 
-    getProjectRootStub = sandbox.stub(process, 'cwd');
+    processCwdStub = sandbox.stub(process, 'cwd');
 
     jestConfigEditor = new JestConfigEditor();
 
@@ -49,7 +48,7 @@ describe('Integration StrykerJestRunner', function () {
   afterEach(() => sandbox.restore());
 
   it('should run tests on the example react project', async () => {
-    getProjectRootStub.returns(getProjectRoot('reactProject'));
+    processCwdStub.returns(getProjectRoot('reactProject'));
     runOptions.strykerOptions.set({ jest: { project: 'react' } });
 
     jestConfigEditor.edit(runOptions.strykerOptions as Config);
@@ -68,7 +67,7 @@ describe('Integration StrykerJestRunner', function () {
   }).timeout(10000);
 
   it('should run tests on the example custom project using package.json', async () => {
-    getProjectRootStub.returns(getProjectRoot('exampleProject'));
+    processCwdStub.returns(getProjectRoot('exampleProject'));
 
     jestConfigEditor.edit(runOptions.strykerOptions as Config);
     const jestTestRunner = new JestTestRunner(runOptions);
@@ -89,7 +88,7 @@ describe('Integration StrykerJestRunner', function () {
   });
 
   it('should run tests on the example custom project using jest.config.js', async () => {
-    getProjectRootStub.returns(getProjectRoot('exampleProjectWithExplicitJestConfig'));
+    processCwdStub.returns(getProjectRoot('exampleProjectWithExplicitJestConfig'));
 
     jestConfigEditor.edit(runOptions.strykerOptions as Config);
     const jestTestRunner = new JestTestRunner(runOptions);

--- a/test/integration/StrykerJestRunnerSpec.ts
+++ b/test/integration/StrykerJestRunnerSpec.ts
@@ -6,11 +6,15 @@ import { expect } from 'chai';
 import JestTestRunner from '../../src/JestTestRunner';
 import * as path from 'path';
 
+// Get the project root, we will be stub process.cwd later on
+const jestProjectRoot = process.cwd();
+
+// Needed for Jest in order to run tests
+process.env.BABEL_ENV = 'test';
+
 describe('Integration StrykerJestRunner', function () {
+  // Set timeout for integration tests to 10 seconds for travis
   this.timeout(10000);
-  const jestTestRunnerRoot = process.cwd();
-  const reactProjectRoot = path.join(jestTestRunnerRoot, 'testResources', 'reactProject');
-  const exampleProjectRoot = path.join(jestTestRunnerRoot, 'testResources', 'exampleProject');
 
   let jestConfigEditor: JestConfigEditor;
   let runOptions: RunnerOptions;
@@ -18,7 +22,15 @@ describe('Integration StrykerJestRunner', function () {
 
   let sandbox: sinon.SinonSandbox;
 
-  process.env.BABEL_ENV = 'test';
+  // Names of the tests in the example projects
+  const testNames = [
+    'Add should be able to add two numbers',
+    'Add should be able to add one to a number',
+    'Add should be able negate a number',
+    'Add should be able to recognize a negative number',
+    'Add should be able to recognize that 0 is not a negative number',
+    'Circle should have a circumference of 2PI when the radius is 1'
+  ];
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -37,7 +49,7 @@ describe('Integration StrykerJestRunner', function () {
   afterEach(() => sandbox.restore());
 
   it('should run tests on the example react project', async () => {
-    getProjectRootStub.returns(reactProjectRoot);
+    getProjectRootStub.returns(getProjectRoot('reactProject'));
     runOptions.strykerOptions.set({ jest: { project: 'react' } });
 
     jestConfigEditor.edit(runOptions.strykerOptions as Config);
@@ -55,17 +67,29 @@ describe('Integration StrykerJestRunner', function () {
     expect(result.status).to.equal(RunStatus.Complete);
   }).timeout(10000);
 
-  it('should run tests on the example custom project', async () => {
-    const testNames = [
-      'Add should be able to add two numbers',
-      'Add should be able to add one to a number',
-      'Add should be able negate a number',
-      'Add should be able to recognize a negative number',
-      'Add should be able to recognize that 0 is not a negative number',
-      'Circle should have a circumference of 2PI when the radius is 1'
-    ];
+  it('should run tests on the example custom project using package.json', async () => {
+    getProjectRootStub.returns(getProjectRoot('exampleProject'));
 
-    getProjectRootStub.returns(exampleProjectRoot);
+    jestConfigEditor.edit(runOptions.strykerOptions as Config);
+    const jestTestRunner = new JestTestRunner(runOptions);
+
+    const result = await jestTestRunner.run();
+
+    expect(result).to.have.property('tests');
+    expect(result.tests).to.be.an('array').with.length(6);
+
+    for (let test of result.tests) {
+      expect(testNames).to.include(test.name);
+      expect(test.status).to.equal(TestStatus.Success);
+      expect(test.timeSpentMs).to.be.above(-1);
+      expect(test.failureMessages).to.be.an('array').that.is.empty;
+    }
+
+    expect(result.status).to.equal(RunStatus.Complete);
+  });
+
+  it('should run tests on the example custom project using jest.config.js', async () => {
+    getProjectRootStub.returns(getProjectRoot('exampleProjectWithExplicitJestConfig'));
 
     jestConfigEditor.edit(runOptions.strykerOptions as Config);
     const jestTestRunner = new JestTestRunner(runOptions);
@@ -85,3 +109,7 @@ describe('Integration StrykerJestRunner', function () {
     expect(result.status).to.equal(RunStatus.Complete);
   });
 });
+
+function getProjectRoot(testResource: string) {
+  return path.join(jestProjectRoot, 'testResources', testResource);
+}

--- a/testResources/exampleProjectWithExplicitJestConfig/jest.config.js
+++ b/testResources/exampleProjectWithExplicitJestConfig/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  collectCoverage: false,
+  moduleFileExtensions: ["js", "json", "jsx", "node"],
+  testEnvironment: "jest-environment-jsdom",
+  testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$",
+  testRunner: "jest-jasmine2",
+  verbose: true
+}

--- a/testResources/exampleProjectWithExplicitJestConfig/package.json
+++ b/testResources/exampleProjectWithExplicitJestConfig/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "example-project",
+  "version": "0.0.0",
+  "description": "A testResource for jest-test-runner"
+}

--- a/testResources/exampleProjectWithExplicitJestConfig/package.json
+++ b/testResources/exampleProjectWithExplicitJestConfig/package.json
@@ -2,5 +2,11 @@
   "private": true,
   "name": "example-project",
   "version": "0.0.0",
-  "description": "A testResource for jest-test-runner"
+  "description": "A testResource for jest-test-runner",
+  "jest": {
+    "moduleFileExtensions": [],
+    "testEnvironment": "some-invalid-test-environment",
+    "testRegex": "not-a-regular-expression",
+    "testRunner": "this-testRunner-does-not-exist"
+  }
 }

--- a/testResources/exampleProjectWithExplicitJestConfig/src/Add.js
+++ b/testResources/exampleProjectWithExplicitJestConfig/src/Add.js
@@ -1,0 +1,20 @@
+exports.add = function(num1, num2) {
+  return num1 + num2;
+};
+
+exports.addOne = function(number) {
+  number++;
+  return number;
+};
+
+exports.negate = function(number) {
+  return -number;
+};
+
+exports.isNegativeNumber = function(number) {
+  var isNegative = false;
+  if(number < 0){
+    isNegative = true;
+  }
+  return isNegative;
+};

--- a/testResources/exampleProjectWithExplicitJestConfig/src/Circle.js
+++ b/testResources/exampleProjectWithExplicitJestConfig/src/Circle.js
@@ -1,0 +1,8 @@
+exports.getCircumference = function(radius) {
+  //Function to test multiple math mutations in a single function.
+  return 2 * Math.PI * radius;
+};
+
+exports.untestedFunction = function() {
+  var i = 5 / 2 * 3;
+};

--- a/testResources/exampleProjectWithExplicitJestConfig/src/__tests__/AddSpec.js
+++ b/testResources/exampleProjectWithExplicitJestConfig/src/__tests__/AddSpec.js
@@ -1,0 +1,50 @@
+var add = require('../Add').add;
+var addOne = require('../Add').addOne;
+var isNegativeNumber = require('../Add').isNegativeNumber;
+var negate = require('../Add').negate;
+
+describe('Add', function() {
+  it('should be able to add two numbers', function() {
+    var num1 = 2;
+    var num2 = 5;
+    var expected = num1 + num2;
+
+    var actual = add(num1, num2);
+
+    expect(actual).toBe(expected);
+  });
+
+  it('should be able to add one to a number', function() {
+    var number = 2;
+    var expected = 3;
+
+    var actual = addOne(number);
+
+    expect(actual).toBe(expected);
+  });
+
+  it('should be able negate a number', function() {
+    var number = 2;
+    var expected = -2;
+
+    var actual = negate(number);
+
+    expect(actual).toBe(expected);
+  });
+
+  it('should be able to recognize a negative number', function() {
+    var number = -2;
+
+    var isNegative = isNegativeNumber(number);
+
+    expect(isNegative).toBe(true);
+  });
+
+  it('should be able to recognize that 0 is not a negative number', function() {
+    var number = 0;
+
+    var isNegative = isNegativeNumber(number);
+
+    expect(isNegative).toBe(false);
+  });
+});

--- a/testResources/exampleProjectWithExplicitJestConfig/src/__tests__/CircleSpec.js
+++ b/testResources/exampleProjectWithExplicitJestConfig/src/__tests__/CircleSpec.js
@@ -1,0 +1,12 @@
+var getCircumference = require('../Circle').getCircumference;
+
+describe('Circle', function() {
+  it('should have a circumference of 2PI when the radius is 1', function() {
+    var radius = 1;
+    var expectedCircumference = 2 * Math.PI;
+
+    var circumference = getCircumference(radius);
+
+    expect(circumference).toBe(expectedCircumference);
+  });
+});


### PR DESCRIPTION
Add the possibility to use the jest.config.js in a jest project, will fallback to using the jest configuration specified in the package.json when the file does not exist. This resolves https://github.com/stryker-mutator/stryker-jest-runner/issues/31

- [x] Add functionality to use jest.config.js
- [x] Add unit tests to cover the new functionality
- [x] Add integration tests 