### PR TITLE
fix(jest-config) Fallback to default Jest config if it's not overriden

### DIFF
--- a/src/JestConfigEditor.ts
+++ b/src/JestConfigEditor.ts
@@ -13,10 +13,10 @@ export default class JestConfigEditor implements ConfigEditor {
     // If there is no Jest property on the Stryker config create it
     strykerConfig.jest = strykerConfig.jest || {};
 
-    // When no project is set set it to 'default'
+    // When no project is set, set it to 'default'
     strykerConfig.jest.project = strykerConfig.jest.project || DEFAULT_PROJECT_NAME;
 
-    // When no config property is set load the configuration with the project type
+    // When no config property is set, load the configuration with the project type
     strykerConfig.jest.config = strykerConfig.jest.config || this.getConfigLoader(strykerConfig.jest.project).loadConfig();
 
     // Override some of the config properties to optimise Jest for Stryker

--- a/src/configLoaders/DefaultJestConfigLoader.ts
+++ b/src/configLoaders/DefaultJestConfigLoader.ts
@@ -19,10 +19,6 @@ export default class DefaultJestConfigLoader implements JestConfigLoader {
   public loadConfig(): JestConfiguration {
     const jestConfig = this.readConfigFromJestConfigFile() || this.readConfigFromPackageJson() || {};
 
-    if (!jestConfig) {
-      throw new Error('Could not read Jest configuration, please provide a jest.config.js file or a jest config in your package.json');
-    }
-
     return jestConfig;
   }
 

--- a/src/configLoaders/DefaultJestConfigLoader.ts
+++ b/src/configLoaders/DefaultJestConfigLoader.ts
@@ -17,7 +17,7 @@ export default class DefaultJestConfigLoader implements JestConfigLoader {
   }
 
   public loadConfig(): JestConfiguration {
-    const jestConfig = this.readConfigFromJestConfigFile() || this.readConfigFromPackageJson();
+    const jestConfig = this.readConfigFromJestConfigFile() || this.readConfigFromPackageJson() || {};
 
     if (!jestConfig) {
       throw new Error('Could not read Jest configuration, please provide a jest.config.js file or a jest config in your package.json');

--- a/test/integration/JestConfigEditorSpec.ts
+++ b/test/integration/JestConfigEditorSpec.ts
@@ -109,6 +109,19 @@ describe('Integration JestConfigEditor', () => {
     });
   });
 
+  it('should load the default Jest configuration if there is no package.json config or jest.config.js', () => {
+    getProjectRootStub.returns(path.join(process.cwd(), 'testResources', 'exampleProjectWithDefaultJestConfig'));
+
+    jestConfigEditor.edit(config);
+
+    expect(config.jest.config).to.deep.equal({
+      bail: false,
+      collectCoverage: false,
+      testResultsProcessor: undefined,
+      verbose: false,
+    });
+  });
+
   it('should return with an error when an invalid project is specified', () => {
     const project = 'invalidProject';
     config.set({ jest: { project } });

--- a/test/unit/configLoaders/DefaultConfigLoaderSpec.ts
+++ b/test/unit/configLoaders/DefaultConfigLoaderSpec.ts
@@ -38,13 +38,6 @@ describe('DefaultJestConfigLoader', () => {
     });
   });
 
-  it('should return an error when no Jest configuration is present in neither jest.config.js or package.json', () => {
-    requireStub.throws(Error('ENOENT: no such file or directory, open jest.config.js'));
-    fsStub.readFileSync.returns('{ "name": "dummy", "version": "0.0.1", "description": "Dummy package.json without jest property"}');
-
-    expect(() => defaultConfigLoader.loadConfig()).to.throw(Error, 'Could not read Jest configuration, please provide a jest.config.js file or a jest config in your package.json');
-  });
-
   it('should fallback and load the Jest configuration from the package.json when jest.config.js is not present in the project', () => {
     requireStub.throws(Error('ENOENT: no such file or directory, open package.json'));
     const config = defaultConfigLoader.loadConfig();
@@ -53,6 +46,13 @@ describe('DefaultJestConfigLoader', () => {
     expect(config).to.deep.equal({
       exampleProperty: 'examplePackageJsonValue'
     });
+  });
+
+  it('should load the default Jest configuration if there is no package.json config or jest.config.js', () => {
+    requireStub.throws(Error('ENOENT: no such file or directory, open package.json'));
+    fsStub.readFileSync.returns('{ }'); // note, no `jest` key here!
+    const config = defaultConfigLoader.loadConfig();
+    expect(config).to.deep.equal({});
   });
 });
 

--- a/testResources/exampleProjectWithDefaultJestConfig/package.json
+++ b/testResources/exampleProjectWithDefaultJestConfig/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "example-project",
+  "version": "0.0.0",
+  "description": "A testResource for jest-test-runner"
+}

--- a/testResources/exampleProjectWithDefaultJestConfig/src/Add.js
+++ b/testResources/exampleProjectWithDefaultJestConfig/src/Add.js
@@ -1,0 +1,20 @@
+exports.add = function(num1, num2) {
+  return num1 + num2;
+};
+
+exports.addOne = function(number) {
+  number++;
+  return number;
+};
+
+exports.negate = function(number) {
+  return -number;
+};
+
+exports.isNegativeNumber = function(number) {
+  var isNegative = false;
+  if(number < 0){
+    isNegative = true;
+  }
+  return isNegative;
+};

--- a/testResources/exampleProjectWithDefaultJestConfig/src/__tests__/AddSpec.js
+++ b/testResources/exampleProjectWithDefaultJestConfig/src/__tests__/AddSpec.js
@@ -1,0 +1,50 @@
+var add = require('../Add').add;
+var addOne = require('../Add').addOne;
+var isNegativeNumber = require('../Add').isNegativeNumber;
+var negate = require('../Add').negate;
+
+describe('Add', function() {
+  it('should be able to add two numbers', function() {
+    var num1 = 2;
+    var num2 = 5;
+    var expected = num1 + num2;
+
+    var actual = add(num1, num2);
+
+    expect(actual).toBe(expected);
+  });
+
+  it('should be able to add one to a number', function() {
+    var number = 2;
+    var expected = 3;
+
+    var actual = addOne(number);
+
+    expect(actual).toBe(expected);
+  });
+
+  it('should be able negate a number', function() {
+    var number = 2;
+    var expected = -2;
+
+    var actual = negate(number);
+
+    expect(actual).toBe(expected);
+  });
+
+  it('should be able to recognize a negative number', function() {
+    var number = -2;
+
+    var isNegative = isNegativeNumber(number);
+
+    expect(isNegative).toBe(true);
+  });
+
+  it('should be able to recognize that 0 is not a negative number', function() {
+    var number = 0;
+
+    var isNegative = isNegativeNumber(number);
+
+    expect(isNegative).toBe(false);
+  });
+});


### PR DESCRIPTION
When Jest config was not overriden (ie., a project uses default Jest settings) Stryker would fail.

Fixes #38