### PR TITLE
fix(stryker init): turn coverage analysis "off"

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
   "dependencies": {
     "log4js": "^1.1.1",
     "semver": "^5.4.1"
+  },
+  "initStrykerConfig": {
+    "coverageAnalysis": "off"
   }
 }


### PR DESCRIPTION
Coverage analysis is not yet supported for the jest test runner. With this setting, `stryker init` will automatically set it off when jest is included.