### PR TITLE
docs: fix redirect link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Hi there! 🙋
 
-This repository has been moved to [https://github.com/stryker-mutator/stryker/tree/master/packages/jest-runner](https://github.com/stryker-mutator/stryker/tree/master/packages/stryker-jest-runner) and will be deleted in the future.
+This repository has been moved to https://github.com/stryker-mutator/stryker/tree/master/packages/jest-runner and will be deleted in the future.


### PR DESCRIPTION
Even though label for the link was updated in previous revision, the underlying link wasn't so the user was redirected to outdated link